### PR TITLE
P siminf changes

### DIFF
--- a/.github/workflows/runcodechunks_vignette.yml
+++ b/.github/workflows/runcodechunks_vignette.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: ubuntu-20.04, r: 'release', mlr3: 'release', DoubleML: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          - {os: macos-11, r: 'release', mlr3: 'release', DoubleML: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true

--- a/.github/workflows/runreplication.yml
+++ b/.github/workflows/runreplication.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: ubuntu-20.04, r: 'release', mlr3: 'release', DoubleML: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          - {os: macos-11, r: 'release', mlr3: 'release', DoubleML: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true

--- a/.github/workflows/runreplication_sim_inf.yml
+++ b/.github/workflows/runreplication_sim_inf.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: ubuntu-20.04, r: 'release', mlr3: 'release', DoubleML: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          - {os: macos-11, r: 'release', mlr3: 'release', DoubleML: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true

--- a/R/sim_siminf.R
+++ b/R/sim_siminf.R
@@ -41,7 +41,7 @@ DGP_desc5 = function(n, p, betamax = 4, decay = 0.99, threshold = 0, noisevar = 
   return(list(data = data.frame(y,x), beta = beta, covar = covar))
 }
 
-R = 250
+R = 500
 
 # correlation for Sigma
 # setting: "medium"
@@ -54,6 +54,7 @@ p = 42
 
 # Parallelized loop
 ncores <- detectCores() - 1
+print(ncores)
 cl <- makeCluster(ncores)
 registerDoParallel(cl)
 

--- a/R/sim_siminf.R
+++ b/R/sim_siminf.R
@@ -41,7 +41,7 @@ DGP_desc5 = function(n, p, betamax = 4, decay = 0.99, threshold = 0, noisevar = 
   return(list(data = data.frame(y,x), beta = beta, covar = covar))
 }
 
-R = 500
+R = 250
 
 # correlation for Sigma
 # setting: "medium"


### PR DESCRIPTION
* Switch to `macos-11` for replication jobs as they offer greater computational resources, see https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources

* Now, simulation jobs (including simultaneous inference) are working again

close #4 